### PR TITLE
Updated the dag to include a new task that sends a notification e-mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ To run the fix linter run
 ```sh
 sh fix_lint
 ```
+
+# Changing the email receiver.
+
+To change who receive the email modify the `receiver_email` variable inside the `send_message_func` function inside the file `dags/process_web_log.py`.

--- a/dags/process_web_log.py
+++ b/dags/process_web_log.py
@@ -6,6 +6,7 @@ import os
 import tarfile
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+from smtplib import SMTP
 
 
 def scan_for_log_func():
@@ -42,19 +43,22 @@ def transform_data_func():
                 destination_file.write(f'{counter}. ' + value + '\n')
                 counter = counter + 1
 
+
 def load_data_func():
     file_transform = io.get_absolute_path(io.Filename.transformed_data)
     tar_file = io.get_absolute_path(io.Filename.weblog)
     with tarfile.open(tar_file, 'w') as tar:
         tar.add(file_transform, arcname=os.path.basename(file_transform))
-        
+
+
 def send_message_func():
     # Email configuration
     sender_email = "jclozdibil27@gmail.com"
     receiver_email = "jose.lozano.dibildox@ulb.be"
-    password = "wuyd dfsc ntue tyix" # App password
+    password = "wuyd dfsc ntue tyix"  # App password
 
-    # Message configuration (change content if you think another version is more appropiate)
+    # Message configuration (change content if you think another version is
+    # more appropiate)
     subject = "Workload success"
     body = "The workflow has been executed"
 
@@ -67,11 +71,15 @@ def send_message_func():
     # Attach the body of the email
     message.attach(MIMEText(body, "plain"))
 
-    with smtplib.SMTP("smtp.gmail.com", 587) as server:
+    with SMTP("smtp.gmail.com", 587) as server:
         server.starttls()  # Start TLS for security
         server.login(sender_email, password)  # Log in to the email account
-        server.sendmail(sender_email, receiver_email, message.as_string())  # Send the email
+        server.sendmail(
+            sender_email,
+            receiver_email,
+            message.as_string())  # Send the email
         server.quit()  # Quit the SMTP server
+
 
 with DAG('process_web_log', start_date=datetime(2023, 1, 1),
          description='Workflow to transform a web server log file', tags=['info-h420'],

--- a/dags/process_web_log.py
+++ b/dags/process_web_log.py
@@ -53,9 +53,9 @@ def load_data_func():
 
 def send_message_func():
     # Email configuration
-    sender_email = "jclozdibil27@gmail.com"
+    sender_email = "testerlozano@gmail.com"
     receiver_email = "jose.lozano.dibildox@ulb.be"
-    password = "wuyd dfsc ntue tyix"  # App password
+    password = "zsjs fwxs dqdw szqe"  # App password
 
     # Message configuration (change content if you think another version is
     # more appropiate)

--- a/dags/process_web_log.py
+++ b/dags/process_web_log.py
@@ -4,6 +4,8 @@ from airflow.operators.python import PythonOperator
 import filenames as io
 import os
 import tarfile
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
 
 
 def scan_for_log_func():
@@ -40,13 +42,36 @@ def transform_data_func():
                 destination_file.write(f'{counter}. ' + value + '\n')
                 counter = counter + 1
 
-
 def load_data_func():
     file_transform = io.get_absolute_path(io.Filename.transformed_data)
     tar_file = io.get_absolute_path(io.Filename.weblog)
     with tarfile.open(tar_file, 'w') as tar:
         tar.add(file_transform, arcname=os.path.basename(file_transform))
+        
+def send_message_func():
+    # Email configuration
+    sender_email = "jclozdibil27@gmail.com"
+    receiver_email = "jose.lozano.dibildox@ulb.be"
+    password = "wuyd dfsc ntue tyix" # App password
 
+    # Message configuration (change content if you think another version is more appropiate)
+    subject = "Workload success"
+    body = "The workflow has been executed"
+
+    # Set up the MIMEText and MIMEMultipart
+    message = MIMEMultipart()
+    message["From"] = sender_email
+    message["To"] = receiver_email
+    message["Subject"] = subject
+
+    # Attach the body of the email
+    message.attach(MIMEText(body, "plain"))
+
+    with smtplib.SMTP("smtp.gmail.com", 587) as server:
+        server.starttls()  # Start TLS for security
+        server.login(sender_email, password)  # Log in to the email account
+        server.sendmail(sender_email, receiver_email, message.as_string())  # Send the email
+        server.quit()  # Quit the SMTP server
 
 with DAG('process_web_log', start_date=datetime(2023, 1, 1),
          description='Workflow to transform a web server log file', tags=['info-h420'],
@@ -64,5 +89,8 @@ with DAG('process_web_log', start_date=datetime(2023, 1, 1),
     load_data = PythonOperator(
         task_id='load_data',
         python_callable=load_data_func)
+    send_message = PythonOperator(
+        task_id='send_message',
+        python_callable=send_message_func)
 
-    scan_for_log >> extract_data >> transform_data >> load_data
+    scan_for_log >> extract_data >> transform_data >> load_data >> send_message


### PR DESCRIPTION
The dag now includes a function to send an e-mail. It uses a specific validation depending on the domain and sends over SMTP protocol. In this case I use a personal gmail account and had to create an application password because the e-mail had 2-step verification. I have also added comments in the task code hoping it explains the process better.

This script was tested in my local repository, but if it's not working please let me know. Also if you run the code and want to make sure I received the e-mail in my account just send me a message, or otherwise change the receiver_email field.

Buen Domingo!